### PR TITLE
fix rendering of unicode characters

### DIFF
--- a/R/kobo_aggregate.R
+++ b/R/kobo_aggregate.R
@@ -37,11 +37,11 @@ kobo_aggregate <- function( form = "form.xlsx",
   ### Load the data ####
   cat("\n\n Loading data. It is assumed that the cleaning, weighting & re-encoding has been done previously \n")
   
-  MainDataFrame <- utils::read.csv(paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""), encoding = "UTF-8", na.strings = "")
+  MainDataFrame <- readr::read_csv(paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""))
   
   ## Load form ###########
   cat("\n\n Loading dictionnary from the xlsform \n")
-  dico <- utils::read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
+  dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"))
   #rm(form)
   
   ## Check that all those selectedVars are in the frame
@@ -169,7 +169,7 @@ kobo_aggregate <- function( form = "form.xlsx",
   datamappoly1L <- kobo_label(datamappoly1, dico)
   
   ## We now save a back up in the data folder to be used for the Rmd
-  write.csv(datamappoly1L,"data/MainDataFrame_edited_map.csv", row.names = FALSE, na = "")
+  readr::write_csv(datamappoly1L,"data/MainDataFrame_edited_map.csv")
   #rm(datamappoly1.cat, datamappoly1.cat2, datamappoly1.n, datamappoly1.num, datamappoly1.num2, datamappoly1)
   
   

--- a/R/kobo_anonymisation_report.R
+++ b/R/kobo_anonymisation_report.R
@@ -42,9 +42,9 @@ kobo_anonymisation_report <- function(frame, form = "form.xlsx", app = "console"
     mainDir <- kobo_getMainDirectory()
     form_tmp <- paste(mainDir, "data", form, sep = "/", collapse = "/")
 
-    dico <- utils::read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
+    dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"))
     framename <- deparse(substitute(frame))
-    utils::write.csv(frame, paste0(mainDir,"/data/anomreport-",framename,".csv"), row.names = FALSE, na = "")
+    readr::write_csv(frame, paste0(mainDir,"/data/anomreport-",framename,".csv"))
 
     ## Check that all those selectedVars are in the frame ####
     check <- as.data.frame(names(frame))
@@ -115,13 +115,12 @@ kobo_anonymisation_report <- function(frame, form = "form.xlsx", app = "console"
           cat("## Provide below the name of the form in xsl form - format should be xls not xlsx", file = reportanom , sep = "\n", append = TRUE)
           cat("form <- \"form.xls\"", file = reportanom , sep = "\n", append = TRUE)
           #cat("kobo_dico(form)", file = reportanom , sep = "\n", append = TRUE)
-          cat("dico <- utils::read.csv(paste0(mainDirroot,\"/data/dico_\",form,\".csv\"), encoding = \"UTF-8\", na.strings = \"\")", file = reportanom , sep = "\n", append = TRUE)
+          cat("dico <- readr::read_csv(paste0(mainDirroot,\"/data/dico_\",form,\".csv\"))", file = reportanom , sep = "\n", append = TRUE)
           cat("\n", file = reportanom , sep = "\n", append = TRUE)
 
-          cat(paste0("dataanom <- utils::read.csv(paste0(mainDirroot,\"/data/anomreport-",framename,".csv\"), sep = \",\", encoding = \"UTF-8\", na.strings = \"\")"), file = reportanom , sep = "\n", append = TRUE)
+          cat(paste0("dataanom <- readr::read_csv(paste0(mainDirroot,\"/data/anomreport-",framename,".csv\"))"), file = reportanom , sep = "\n", append = TRUE)
 
 
-        #  cat(paste0("dataanom <- read.csv(paste0(mainDirroot,\"/data/anomreport-",framename,".csv\")    , sep = \";\", encoding = \"UTF-8\", na.strings = \"\")", file = reportanom , sep = "\n", append = TRUE))
           cat("\n", file = reportanom , sep = "\n", append = TRUE)
           cat("numrow <- nrow(dataanom) ", file = reportanom , sep = "\n", append = TRUE)
           cat("numvar <- ncol(dataanom)", file = reportanom , sep = "\n", append = TRUE)

--- a/R/kobo_anonymise.R
+++ b/R/kobo_anonymise.R
@@ -50,7 +50,7 @@ kobo_anonymise <- function(frame, form = "form.xlsx", app = "console") {
   mainDir <- kobo_getMainDirectory()
   form_tmp <- paste(mainDir, "data", form, sep = "/", collapse = "/")
 
-  dico <- utils::read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
+  dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"))
 
   # frame <- household
   # framename <- "household"
@@ -171,7 +171,7 @@ kobo_anonymise <- function(frame, form = "form.xlsx", app = "console") {
           cat(paste0(formula2, "} else"), file = "code/temp-reference.R" , sep = "\n", append = TRUE)
           cat("{}", file = "code/temp-reference.R" , sep = "\n", append = TRUE)
         }
-        formula3 <- paste0( "write.csv(",framename,".anom.reference, \"data/anom_reference_",framename,".csv\", row.names = FALSE, na = \"\")")
+        formula3 <- paste0( "readr::write_csv(",framename,".anom.reference, \"data/anom_reference_",framename,".csv)")
         cat(formula3, file = "code/temp-reference.R" , sep = "\n", append = TRUE)
 
         #  mainDir <- getwd()

--- a/R/kobo_atlas_report.R
+++ b/R/kobo_atlas_report.R
@@ -56,7 +56,7 @@ kobo_atlas_report <- function(form = "form.xlsx",
     ### Load the data
     cat("\n\n Loading data. It is assumed that the cleaning, weighting & re-encoding has been done previously \n")
     
-    MainDataFrame <- utils::read.csv(paste(mainDir,"/data/MainDataFrame_encoded.csv",sep = ""), encoding = "UTF-8", na.strings = "")
+    MainDataFrame <- readr::read_csv(paste(mainDir,"/data/MainDataFrame_encoded.csv",sep = ""))
     
     
     # Form ##########################################
@@ -68,7 +68,7 @@ kobo_atlas_report <- function(form = "form.xlsx",
     #kobo_dico(form)
     
     ## Load dictionnary
-    dico <- utils::read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
+    dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"))
     #rm(form)
     
     
@@ -86,7 +86,7 @@ kobo_atlas_report <- function(form = "form.xlsx",
     kobo_aggregate(form,
                    aggregVar = mapref)
     
-    MainDataFrameMap <- utils::read.csv(paste(mainDir,"/data/MainDataFrame_edited_map.csv",sep = ""), encoding = "UTF-8", na.strings = "")
+    MainDataFrameMap <- readr::read_csv(paste(mainDir,"/data/MainDataFrame_edited_map.csv",sep = ""))
     
     ##get list of report
     reports <- as.data.frame(unique(dico$report))
@@ -104,7 +104,7 @@ kobo_atlas_report <- function(form = "form.xlsx",
     
     names(reports)[1] <- "Report"
     
-    utils::write.csv(reports, paste(mainDir,"/data/mapreports.csv",sep = ""), row.names = FALSE, na = "")
+    readr::write_csv(reports, paste(mainDir,"/data/mapreports.csv",sep = ""))
     
     
     ## For each Report: create a Rmd file -------
@@ -233,14 +233,14 @@ kobo_atlas_report <- function(form = "form.xlsx",
       
       cat("## Provide below the name of the form in xsl form - format should be xls not xlsx", file = report.name , sep = "\n", append = TRUE)
       cat(paste0("form <- \"",form,"\""), file = report.name , sep = "\n", append = TRUE)
-      cat("dico <- utils::read.csv(paste0(mainDirroot,\"/data/dico_\",form,\".csv\"), encoding = \"UTF-8\", na.strings = \"\")", file = report.name , sep = "\n", append = TRUE)
+      cat("dico <- readr::read_csv(paste0(mainDirroot,\"/data/dico_\",form,\".csv\"))", file = report.name , sep = "\n", append = TRUE)
       
       
       ## TO DO: Use config file to load the different frame
       
       
-      cat("MainDataFrameMap <- utils::read.csv(paste0(mainDirroot,\"/data/MainDataFrame_edited_map.csv\"), encoding = \"UTF-8\", na.strings = \"\")", file = report.name , sep = "\n", append = TRUE)
-      cat("MainDataFrame <- utils::read.csv(paste0(mainDirroot,\"/data/MainDataFrame_encoded.csv\"), encoding = \"UTF-8\", na.strings = \"\")", file = report.name , sep = "\n", append = TRUE)
+      cat("MainDataFrameMap <- readr::read_csv(paste0(mainDirroot,\"/data/MainDataFrame_edited_map.csv\"))", file = report.name , sep = "\n", append = TRUE)
+      cat("MainDataFrame <- readr::read_csv(paste0(mainDirroot,\"/data/MainDataFrame_encoded.csv\"))", file = report.name , sep = "\n", append = TRUE)
       cat("\n", file = report.name , sep = "\n", append = TRUE)
       cat("## label Variables", file = report.name , sep = "\n", append = TRUE)
       cat("MainDataFrameMap <- kobo_label(MainDataFrameMap , dico)", file = report.name , sep = "\n", append = TRUE)
@@ -751,7 +751,7 @@ kobo_atlas_report <- function(form = "form.xlsx",
       #rm(list = ls())
       kobo_load_packages()
       mainDir <- kobo_getMainDirectory()
-      reports <- utils::read.csv(paste(mainDir,"/data/mapreports.csv",sep = ""), encoding = "UTF-8", na.strings = "")
+      reports <- readr::read_csv(paste(mainDir,"/data/mapreports.csv",sep = ""))
       ### Render now all reports
       cat(" Render now reports... \n")
       for (i in 1:nrow(reports)) {

--- a/R/kobo_clean.R
+++ b/R/kobo_clean.R
@@ -32,7 +32,7 @@ kobo_clean <- function(frame, form = "form.xlsx", app = "console") {
   #cat(paste0(form,"\n"))
   formpath <- as.character(paste0(mainDir,"/data/dico_",form,".csv"))
   #cat(paste0(formpath,"\n"))
-  dico <- utils::read.csv(formpath, encoding = "UTF-8", na.strings = "")
+  dico <- readr::read_csv(formpath)
   
   
   #formpath <- as.character(paste0(mainDir,"/data/dico_",form,".rda"))
@@ -64,7 +64,7 @@ kobo_clean <- function(frame, form = "form.xlsx", app = "console") {
             variable <- paste0(as.character(dico.clean[ i, c("fullname")]))
             cleanfile <- paste0(as.character(dico.clean[ i, c("clean")]))
             cleanframe <- paste0(substr(as.character(dico.clean[ i, c("clean")]), 1, nchar(cleanfile) - 4))
-            formula1 <-  paste0(cleanframe," <- utils::read.csv(\"data-raw/", cleanfile,"\", encoding = \"UTF-8\", na.strings = \"\")" )
+            formula1 <-  paste0(cleanframe," <- readr::read_csv(\"data-raw/", cleanfile)
             formula2 <- paste0("names(",cleanframe,")[1] <- \"",dico.clean[ i, c("fullname")],"\"" )
             formula3 <- paste0("names(",cleanframe,")[2] <- \"",dico.clean[ i, c("fullname")],".clean\"" )
             formula4 <- paste0("colname <- which(colnames(",framename,") == \"", variable,"\")")

--- a/R/kobo_cluster_report.R
+++ b/R/kobo_cluster_report.R
@@ -58,7 +58,7 @@ kobo_cluster_report <- function(frame =  MainDataFrame ,
     names(check)[1] <- "fullname"
     check$id <- row.names(check)
 
-    dico <- utils::read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
+    dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
 
     #### Check presence of variable for anom plan...
     if (app == "shiny") {
@@ -96,7 +96,7 @@ kobo_cluster_report <- function(frame =  MainDataFrame ,
     framecluster <- paste0(mainDir,"/data/clustering-report-",framename,".csv")
     if (file.exists(framecluster)) file.remove(framecluster)
     
-    utils::write.csv(frame, framecluster,  row.names = FALSE)
+    readr::write_csv(frame, framecluster)
 
     if (nrow(selected.cluster) == 0) {
       cat("You have not selected variables to cluster for your dataset! \n")
@@ -232,10 +232,10 @@ kobo_cluster_report <- function(frame =  MainDataFrame ,
           cat("## Provide below the name of the form in xsl form - format should be xls not xlsx", file = reportcluster , sep = "\n", append = TRUE)
           cat("form <- \"form.xls\"", file = reportcluster , sep = "\n", append = TRUE)
           cat("\n", file = reportcluster , sep = "\n", append = TRUE)
-          cat("dico <- utils::read.csv(paste0(mainDirroot,\"/data/dico_\",form,\".csv\"), encoding = \"UTF-8\", na.strings = \"\")", file = reportcluster , sep = "\n", append = TRUE)
+          cat("dico <- readr::read_csv(paste0(mainDirroot,\"/data/dico_\",form,\".csv\"))", file = reportcluster , sep = "\n", append = TRUE)
           cat("\n", file = reportcluster , sep = "\n", append = TRUE)
 
-          cat(paste0("datacluster <-  utils::read.csv(paste0(mainDirroot,\"/data/clustering-report-",framename,".csv\"), sep = \",\", encoding = \"UTF-8\", na.strings = \"\")"), file = reportcluster , sep = "\n", append = TRUE)
+          cat(paste0("datacluster <-  readr::read_csv(paste0(mainDirroot,\"/data/clustering-report-",framename,".csv\"))"), file = reportcluster , sep = "\n", append = TRUE)
          
           cat("\n", file = reportcluster , sep = "\n", append = TRUE)
           cat("```", file = reportcluster , sep = "\n", append = TRUE)

--- a/R/kobo_consolidateone.R
+++ b/R/kobo_consolidateone.R
@@ -24,7 +24,7 @@ kobo_consolidateone <- function(frame , form = "form.xlsx") {
 
   configInfo <- kobo_get_config()
   mainDir <- kobo_getMainDirectory()
-  dico <- utils::read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
+  dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"))
 
 
   ### List of select_one questions

--- a/R/kobo_correlation_analysis.R
+++ b/R/kobo_correlation_analysis.R
@@ -32,7 +32,7 @@ kobo_correlation_analysis <- function(form = "form.xlsx", frame, target, app = "
     }
     mainDir <- kobo_getMainDirectory()
 
-    dico <- utils::read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "", stringsAsFactors = F)
+    dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"))
 
     dico <- dico[c("type","fullname","variable","listname","labelchoice","order")]
     names(dico) <- c("type","name","variable","listname","labelchoice","order")

--- a/R/kobo_create_indicators.R
+++ b/R/kobo_create_indicators.R
@@ -46,7 +46,7 @@ kobo_create_indicators <- function(form = "form.xlsx") {
       ## Check if there's a repeat - aka hierarchical structure in the dataset
       if  (length(dataBeginRepeat) > 0) {
         for (dbr in dataBeginRepeat) {
-          dataFrame <- utils::read.csv(paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""),stringsAsFactors = F)
+          dataFrame <- readr::read_csv(paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""))
           #load(paste(mainDir,"/data/",dbr,"_edited.rda",sep = ""))
           
           assign(dbr, dataFrame)
@@ -61,7 +61,7 @@ kobo_create_indicators <- function(form = "form.xlsx") {
         ## Load data & dico #############################################################################
         #form <- "form.xls"
         ## Run this only after data cleaning
-         dico <- utils::read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
+         dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"))
         #load(paste(mainDir,"/data/dico_",form,".rda",sep = ""))
         ## Create the dicotemp #############################################################################
         #names(dico)
@@ -126,13 +126,13 @@ kobo_create_indicators <- function(form = "form.xlsx") {
         cat('dataBeginRepeat <- koboloadeR::kobo_get_begin_repeat(form)', file = paste0(mainDir,"/R/build_indicator.R") , sep = "\n", append = TRUE)
         cat('dataBeginRepeat <- dataBeginRepeat$names', file = paste0(mainDir,"/R/build_indicator.R") , sep = "\n", append = TRUE)
         
-         cat('MainDataFrame <- utils::read.csv(paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""), encoding = "UTF-8", na.strings = "NA")', file = paste0(mainDir,"/R/build_indicator.R") , sep = "\n", append = TRUE)
+         cat('MainDataFrame <- readr::read_csv(paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""))', file = paste0(mainDir,"/R/build_indicator.R") , sep = "\n", append = TRUE)
         #cat('load(paste(mainDir,"/data/MainDataFrame_edited.rda",sep = ""))', file = paste0(mainDir,"/R/build_indicator.R") , sep = "\n", append = TRUE)
         
         ## Check if there's a repeat - aka hierarchical structure in the dataset
         if  (length(dataBeginRepeat) > 0) {
           cat('for (dbr in dataBeginRepeat) {
-            dataFrame <- utils::read.csv(paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""),stringsAsFactors = F)
+            dataFrame <- readr::read_csv(paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""),stringsAsFactors = F)
             #load(paste(mainDir,"/data/",dbr,"_edited.rda",sep = ""))
 
             assign(paste0(dbr,"_edited"), dataFrame)  }', file = paste0(mainDir,"/R/build_indicator.R") , sep = "\n", append = TRUE)
@@ -241,7 +241,7 @@ kobo_create_indicators <- function(form = "form.xlsx") {
           dicotemp <- rbind(dicotemp,dicotemp1)
 
         }
-         cat('utils::write.csv(MainDataFrame, paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""), row.names = FALSE, na = "")', file = paste0(mainDir,"/R/build_indicator.R") , sep = "\n", append = TRUE)
+         cat('readr::write_csv(MainDataFrame, paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""))', file = paste0(mainDir,"/R/build_indicator.R") , sep = "\n", append = TRUE)
         #cat('save(MainDataFrame, file =   paste(mainDir,"/data/MainDataFrame_edited.rda",sep = ""))', file = paste0(mainDir,"/R/build_indicator.R") , sep = "\n", append = TRUE)
         
         source(paste0(mainDir,"/R/build_indicator.R"))
@@ -421,7 +421,7 @@ kobo_create_indicators <- function(form = "form.xlsx") {
         rm(dicotemp,dicotemp1, choices, choices2, choices3, dicotemp.choice)
 
 
-         MainDataFrame <- utils::read.csv(paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""), encoding = "UTF-8", na.strings = "NA")
+         MainDataFrame <- readr::read_csv(paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""))
         #load(paste(mainDir,"/data/MainDataFrame_edited.rda",sep = ""))
         
         ## label Variables
@@ -431,19 +431,19 @@ kobo_create_indicators <- function(form = "form.xlsx") {
         ## Check if there's a repeat - aka hierarchical structure in the dataset
         if  (length(dataBeginRepeat) > 0) {
           for (dbr in dataBeginRepeat) {
-            dataFrame <- utils::read.csv(paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""),stringsAsFactors = F)
+            dataFrame <- readr::read_csv(paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""),stringsAsFactors = F)
             #load(paste(mainDir,"/data/",dbr,"_edited.rda",sep = ""))
   
             dataFrame <- koboloadeR::kobo_label(dataFrame, dico)
-            utils::write.csv(dataFrame,paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""), row.names = FALSE, na = "")
+            readr::write_csv(dataFrame,paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""))
             #save(dataFrame , file =  paste(mainDir,"/data/",dbr,"_edited.rda",sep = ""))
           }
         }
         cat("\n\nWrite dico\n")
-       utils::write.csv(dico, paste0(mainDir,"/data/dico_",form,".csv"), row.names = FALSE, na = "")
+        readr::write_csv(dico, paste0(mainDir,"/data/dico_",form,".csv"))
         # save(dico, file =   paste0(mainDir,"/data/dico_",form,".rda"))
 
-        utils::write.csv(MainDataFrame, paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""), row.names = FALSE, na = "")    
+        readr::write_csv(MainDataFrame, paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""))    
         
         #save(MainDataFrame, file =   paste(mainDir,"/data/MainDataFrame_edited.rda",sep = ""))
 

--- a/R/kobo_ddi.R
+++ b/R/kobo_ddi.R
@@ -39,7 +39,7 @@ kobo_ddi <- function(form = "form.xlsx", app="console") {
 
     mainDir <- kobo_getMainDirectory()
     form_tmp <- paste(mainDir, "data", form, sep = "/", collapse = "/")
-    dico <- read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
+    dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"))
 
     survey <- tryCatch({
       as.data.frame(read_excel(form_tmp, sheet = "survey"),
@@ -219,7 +219,7 @@ kobo_ddi <- function(form = "form.xlsx", app="console") {
         next
       }
       count  <- count + 1
-      dataFrame <- read.csv(paste(mainDir,"/data/",dbr,"-edited.csv",sep = ""),stringsAsFactors = F)
+      dataFrame <- readr::read_csv(paste(mainDir,"/data/",dbr,"-edited.csv",sep = ""),stringsAsFactors = F)
       dataFrame <- kobo_split_multiple(dataFrame, dico)
       #dataFrame <- kobo_clean(dataFrame, dico)
       dataFrame <- kobo_label(dataFrame, dico)
@@ -232,7 +232,7 @@ kobo_ddi <- function(form = "form.xlsx", app="console") {
                                                                                   ifelse(parent == "household","MainDataFrame",parent))), "value"]
         instanceIDParent <- configInfo[tolower(configInfo$name) == tolower(paste0("instanceid_",
                                                                                   ifelse(parent == "household","MainDataFrame",parent),"_",child)), "value"]
-        parentDf <- read.csv(paste(mainDir,"/data/",parent,".csv",sep = ""),stringsAsFactors = F)
+        parentDf <- readr::read_csv(paste(mainDir,"/data/",parent,".csv",sep = ""),stringsAsFactors = F)
         unColChild <- dataFrame[,instanceIDChild]
         dataFrame <- dataFrame[,colnames(dataFrame) != instanceIDChild]
         unCN <- colnames(dataFrame)[!colnames(dataFrame) %in% colnames(parentDf)]
@@ -249,13 +249,13 @@ kobo_ddi <- function(form = "form.xlsx", app="console") {
         }
 
       }
-      write.csv(dataFrame,paste(mainDir,"/data/group",count,".csv",sep = ""), row.names = FALSE, na = "")
+      readr::write_csv(dataFrame,paste(mainDir,"/data/group",count,".csv",sep = ""))
     }
 
-    allframes <- read.csv(paste(mainDir,"/data/group",count,".csv",sep = ""), stringsAsFactors = F)
+    allframes <- readr::read_csv(paste(mainDir,"/data/group",count,".csv",sep = ""), stringsAsFactors = F)
     count <- count - 1
     while (count) {
-      temp <- read.csv(paste(mainDir,"/data/group",count,".csv",sep = ""), stringsAsFactors = F)
+      temp <- readr::read_csv(paste(mainDir,"/data/group",count,".csv",sep = ""), stringsAsFactors = F)
 
       unColChild <- temp[,"responseID"]
       temp <- temp[,colnames(temp) != instanceIDChild]

--- a/R/kobo_dico.R
+++ b/R/kobo_dico.R
@@ -600,7 +600,7 @@ kobo_dico <- function(form = "form.xlsx") {
   #} else { dico$type <- dico$type
   #  cat("Note that select_one & select_multiple questions within REPEAT part are converted to integer (results are summed up).\n")
 
-  utils::write.csv(dico, paste0(mainDir,"/data/dico_",form,".csv"), row.names = FALSE, na = "")
+  readr::write_csv(dico, paste0(mainDir,"/data/dico_",form,".csv"))
   #save(dico, file =  paste0(mainDir,"/data/dico_",form,".rda"))
   # f_csv(dico)
   #  return(dico)

--- a/R/kobo_dummy.R
+++ b/R/kobo_dummy.R
@@ -54,9 +54,9 @@ kobo_dummy <- function(form = "form.xlsx") {
   #form <- "form.xls"
   #library(koboloadeR)
   kobo_dico(form)
-  # dico <- utils::read.csv("data/dico_form.xls.csv")
+  # dico <- readr::read_csv("data/dico_form.xls.csv")
   #dico <- paste(mainDir, "data", dico, sep = "/", collapse = "/")
-  dico <- utils::read.csv(paste0(mainDir, "/data/dico_", form, ".csv"))
+  dico <- readr::read_csv(paste0(mainDir, "/data/dico_", form, ".csv"))
 
   ## Extract constraint on data ###########
   ## From constraint  lower bounds &  upper bound
@@ -299,7 +299,7 @@ kobo_dummy <- function(form = "form.xlsx") {
       }
     }
   }
-  utils::write.csv(dummydata, "data/MainDataFrame.csv", row.names = FALSE)
+  readr::write_csv(dummydata, "data/MainDataFrame.csv")
 
   rm(categ_level, fullname, i , l, listname, lowerbound, upperbound, value, datacheck, dico.household,
      relevantifvalue, relevantifvar, relevantifvar2, samplesize, typedata)
@@ -492,7 +492,7 @@ kobo_dummy <- function(form = "form.xlsx") {
           }
         }
    # }
-    utils::write.csv(dummydatarepeatall, paste0("data/",repeat_table,".csv"), row.names = FALSE)
+    readr::write_csv(dummydatarepeatall, paste0("data/",repeat_table,".csv"))
     cat(paste0("\n\n\n Finished generation of nested table ", h, " - ", repeat_table, "\n"))
     rm(dummydatarepeatall)
 

--- a/R/kobo_encode.R
+++ b/R/kobo_encode.R
@@ -24,8 +24,8 @@
 kobo_encode <- function(data, dico) {
   ### First we provide attribute label to variable name
   #data1 <- data
-  # MainDataFrame <- read.csv("data/MainDataFrame_edited.csv")
-  # dico <- read.csv("data/dico_form.xls.csv", comment.char="#")
+  # MainDataFrame <- read_csv("data/MainDataFrame_edited.csv")
+  # dico <- read_csv("data/dico_form.xls.csv", comment.char="#")
   # data <- MainDataFrame
   data.label <- as.data.frame(names(data))
   names(data.label)[1] <- "fullname"

--- a/R/kobo_indicator.R
+++ b/R/kobo_indicator.R
@@ -131,12 +131,7 @@ kobo_indicator <- function(mainDir = '') {
       }
     }
     # Rewritting dico file
-    write.csv(
-      dico,
-      paste0(mainDir, "/data/dico_", form, ".csv"),
-      row.names = FALSE,
-      na = ""
-    )
+    readr::write_csv(dico, paste0(mainDir, "/data/dico_", form, ".csv"))
 
     # Rewritting data file
     # Coherce data to a clean dataframe

--- a/R/kobo_label.R
+++ b/R/kobo_label.R
@@ -30,7 +30,7 @@ kobo_label <- function(datalabel, dico) {
   data.label <- as.data.frame(names(datalabel))
   names(data.label)[1] <- "fullname"
   data.label <- plyr::join(x = data.label, y = dico, by = "fullname", type = "left" )
-  # write.csv(data.label, "out/datalabel.csv")
+  # readr::write_csv(data.label, "out/datalabel.csv")
   for (i in 1:nrow(data.label)) { attributes(datalabel)$variable.labels[ i] <- as.character(data.label[ i, c("labelReport")]) }
   test <- data.label[ !(is.na(data.label$name)), ]
   if (nrow(data.label) > nrow(test)) {

--- a/R/kobo_load_data.R
+++ b/R/kobo_load_data.R
@@ -67,19 +67,19 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
     cat("\n\n\n Generate dictionnary from the xlsform \n\n\n\n")
     mainDir <- koboloadeR::kobo_getMainDirectory()
     koboloadeR::kobo_dico(form)
-    dico <- utils::read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
+    dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"))
     #load(paste0(mainDir,"/data/dico_",form,".rda"))
 
     ## Load data #######################################################################
     cat("\n\n\n Load original dataset \n\n\n\n")
 
     # originalData <- readr::read_csv(paste0(mainDir, "/data-raw/",configInfoOrigin[configInfoOrigin$name == "MainDataFrame", "path"]))
-    originalData <- utils::read.csv(paste0(mainDir, "/data-raw/",configInfoOrigin[configInfoOrigin$name == "MainDataFrame", "path"]), sep = ",", encoding = "UTF-8", na.strings = "")
+    originalData <- readr::read_csv(paste0(mainDir, "/data-raw/",configInfoOrigin[configInfoOrigin$name == "MainDataFrame", "path"]))
 
     if (ncol(originalData) == 1) {
       cat("seems like you file use  ; rather , variable separator.... \n")
       # originalData <- readr::read_csv(paste0(mainDir, "/data-raw/",configInfoOrigin[configInfoOrigin$name == "MainDataFrame", "path"]))
-      originalData <- utils::read.csv(paste0(mainDir, "/data-raw/",configInfoOrigin[configInfoOrigin$name == "MainDataFrame", "path"]), sep = ";", encoding = "UTF-8", na.strings = "")
+      originalData <- readr::read_csv2(paste0(mainDir, "/data-raw/",configInfoOrigin[configInfoOrigin$name == "MainDataFrame", "path"]))
     }
 
     ## Check to split select_multiple if data is extracted from ODK ###################
@@ -122,7 +122,7 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
         }
 
         path <- configInfoOrigin[configInfoOrigin$name == "weights_info", "path"]
-        weight <- utils::read.csv(paste0(mainDir, "/data-raw/",path),stringsAsFactors = F)
+        weight <- readr::read_csv(paste0(mainDir, "/data-raw/",path),stringsAsFactors = F)
 
 
         variableName <- configInfoOrigin[configInfoOrigin$name == "variable_name", "value"]
@@ -150,7 +150,7 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
 
 
     cat("\n\n Write backup before encoding or indicators calculation..\n")
-    utils::write.csv(MainDataFrame,paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""), row.names = FALSE, na = "")
+    readr::write_csv(MainDataFrame,paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""))
     #save(MainDataFrame, file =  paste(mainDir,"/data/MainDataFrame_edited.rda",sep = ""))
 
 
@@ -187,7 +187,7 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
         # dbr <- levelsOfDF$name[1]
         cat("\n\nloading",dbr,"file ..\n")
         # dataFrame <- readr::read_csv(paste0(mainDir, "/data-raw/",configInfoOrigin[configInfoOrigin$name == dbr,"path"]))
-       dataFrame <- utils::read.csv(paste0(mainDir, "/data-raw/",configInfoOrigin[configInfoOrigin$name == dbr,"path"]), stringsAsFactors = F)
+       dataFrame <- readr::read_csv(paste0(mainDir, "/data-raw/",configInfoOrigin[configInfoOrigin$name == dbr,"path"]), stringsAsFactors = F)
 
         if (app == "shiny") {
           progress$set(message = paste("Splitting",dbr,"file in progress..."))
@@ -224,7 +224,7 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
 
 
         cat("\n\n Saving ",dbr,"file as _edited..\n")
-        utils::write.csv(dataFrame,paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""), row.names = FALSE, na = "")
+        readr::write_csv(dataFrame,paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""))
         #save(dataFrame, file =  paste(mainDir,"/data/",dbr,"_edited.rda",sep = ""))
 
       # }
@@ -238,7 +238,7 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
         #   updateProgress()
         # }
         #
-        # dataFrame <- utils::read.csv(paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""),stringsAsFactors = F)
+        # dataFrame <- readr::read_csv(paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""),stringsAsFactors = F)
         child <- levelsOfDF[levelsOfDF$name == dbr, "name"]
         parent <- levelsOfDF[levelsOfDF$name == dbr, "parent"]
 
@@ -250,11 +250,11 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
 
           ## Case MainDataFrame called household
           if (parent %in% c("household", "MainDataFrame")) {
-            parentDf <- utils::read.csv(paste(mainDir,"/data/",parent,"_edited.csv",sep = ""),stringsAsFactors = F)
+            parentDf <- readr::read_csv(paste(mainDir,"/data/",parent,"_edited.csv",sep = ""),stringsAsFactors = F)
            # load(paste(mainDir,"/data/",parent,"_edited.rda",sep = ""))
 
           }else{
-            parentDf <- utils::read.csv(paste(mainDir,"/data/",parent,"_edited.csv",sep = ""),stringsAsFactors = F)
+            parentDf <- readr::read_csv(paste(mainDir,"/data/",parent,"_edited.csv",sep = ""),stringsAsFactors = F)
             #load(paste(mainDir,"/data/",parent,"_edited.rda",sep = ""))
           }
 
@@ -297,7 +297,7 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
         }
 
         cat("\n\n Saving edited version of  ", dbr, " ...\n")
-        utils::write.csv(dataFrame,paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""), row.names = FALSE, na = "")
+        readr::write_csv(dataFrame,paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""))
         #save(dataFrame, file =  paste(mainDir,"/data/",dbr,"_edited.rda",sep = ""))
 
       }
@@ -320,11 +320,11 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
     }
 
 
-    dico <- utils::read.csv(paste0(mainDir,"/data/dico_",form,".csv"), encoding = "UTF-8", na.strings = "")
+    dico <- readr::read_csv(paste0(mainDir,"/data/dico_",form,".csv"))
     #load(paste(mainDir,"/data/dico_",form,".rda",sep = ""))
 
 
-    MainDataFrame <- utils::read.csv(paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""), encoding = "UTF-8", na.strings = "NA")
+    MainDataFrame <- readr::read_csv(paste(mainDir,"/data/MainDataFrame_edited.csv",sep = ""))
     #load(paste(mainDir,"/data/MainDataFrame_edited.rda",sep = ""))
 
 
@@ -342,12 +342,12 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
     ## loading nested frame
     for (dbr in levelsOfDF$name) {
 
-      dataFrame <- utils::read.csv(paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""),stringsAsFactors = F)
+      dataFrame <- readr::read_csv(paste(mainDir,"/data/",dbr,"_edited.csv",sep = ""),stringsAsFactors = F)
       #load(paste(mainDir,"/data/",dbr,"_edited.rda",sep = ""))
 
       dataFrame <- koboloadeR::kobo_encode(dataFrame, dico)
 
-      utils::write.csv(dataFrame,paste(mainDir,"/data/",dbr,"_encoded.csv",sep = ""), row.names = FALSE, na = "")
+      readr::write_csv(dataFrame,paste(mainDir,"/data/",dbr,"_encoded.csv",sep = ""))
       #save(dataFrame, file =  paste(mainDir,"/data/",dbr,"_encoded.rda",sep = ""))
 
       cat("\n\nRe-encode",dbr,"..\n")
@@ -356,7 +356,7 @@ kobo_load_data <- function(form = "form.xlsx", app = "console") {
       updateProgress()
     }
 
-    utils::write.csv(MainDataFrame,paste(mainDir,"/data/MainDataFrame_encoded.csv",sep = ""), row.names = FALSE, na = "")
+    readr::write_csv(MainDataFrame,paste(mainDir,"/data/MainDataFrame_encoded.csv",sep = ""))
     #save(MainDataFrame, file =  paste(mainDir,"/data/MainDataFrame_encoded.rda",sep = ""))
 
     return(TRUE)

--- a/R/kobo_registration.R
+++ b/R/kobo_registration.R
@@ -1032,9 +1032,9 @@ prop.table(table(progres.case$occupationcat, useNA = "ifany"))
 #str(progres.case$occupationcat)
 ##  International Standard Classification of Occupations (ISCO)
 # http://www.ilo.org/public/english/bureau/stat/isco/isco08/
-#ISCO.08 <- read.csv("data/ISCO-08.csv")
+#ISCO.08 <- read_csv("data/ISCO-08.csv")
 #names(ISCO.08)
-#corrtab88.08 <- read.csv("data/corrtab88-08.csv")
+#corrtab88.08 <- read_csv("data/corrtab88-08.csv")
 #names(corrtab88.08)
 #isco <- merge(x=ISCO.08, y=corrtab88.08, by.x="ISCO08Code", by.y="ISCO.08.Code")
 #utils::write.csv(isco, "out/isco.csv")
@@ -1211,6 +1211,6 @@ prop.table(table(progres.case.sp$Victim.of.Violence, useNA = "ifany"))
 prop.table(table(progres.case.sp$Woman.at.Risk, useNA = "ifany"))
 
 
-utils::write.csv(progres.case.sp, file = "data/progrescase-1.csv", na = "", row.names = FALSE)
+readr::write_csv(progres.case.sp, file = "data/progrescase-1.csv")
 
 }

--- a/R/kobo_split_multiple.R
+++ b/R/kobo_split_multiple.R
@@ -27,12 +27,13 @@ kobo_split_multiple <- function(data, dico) {
   #rm(datalabel)
   # data <- household
   # data <- data.or
+  data <- data %>% dplyr::select(-dplyr::starts_with(paste0(selectdf$fullname, ".")))
   datalabeldf <- as.data.frame( names(data))
   data <- as.data.frame(data)
   names(datalabeldf )[1] <- "fullname"
   datalabeldf$fullname <- as.character(datalabeldf$fullname)
   datalabeldf$id <- row.names(datalabeldf)
-  datalabeldf <- join(x = datalabeldf,y = selectdf,by = "fullname",type = "right")
+  datalabeldf <- plyr::join(x = datalabeldf,y = selectdf,by = "fullname",type = "right")
   ## Eliminate record from the wrong frame -i.e. id is NULL -
   datalabeldf <- datalabeldf[ !(is.na(datalabeldf$id)), ]
 
@@ -63,12 +64,12 @@ kobo_split_multiple <- function(data, dico) {
 
    # nrow(data[data[ , id]=='', id])
 
-    data[is.na(data[ , id]), id] <- "zNotAnswered"
-    data[data[ , id] =='', id] <- "zNotAnswered"
+    data[is.na(data[[id]]), id] <- "zNotAnswered"
+    data[data[[id]] =='', id] <- "zNotAnswered"
 
     #levels(as.factor(data[ , id]))
     #levels(data[ , id])
-    list <- as.data.frame(data[ , id])
+    list <- as.data.frame(data[[id]])
 
     ## thanks to: https://stackoverflow.com/questions/44232180/list-to-dataframe
     tosplitlist <- strsplit(as.character(data[ , id]), " ")

--- a/R/kobo_weight.R
+++ b/R/kobo_weight.R
@@ -150,7 +150,7 @@ kobo_weight <- function(mainDir = '') {
         data <- data.frame(data)
 
         #Write data with weights
-        write.csv(data, file = paste0(mainDir,"/data/data.csv"))
+        readr::write_csv(data, file = paste0(mainDir,"/data/data.csv"))
 
         path.to.data <- paste0(mainDir, "/data/data.csv")
 
@@ -161,7 +161,7 @@ kobo_weight <- function(mainDir = '') {
         sink(configfile, append = TRUE)
 
         cat("\n")
-        cat(paste0('data <- read.csv("',path.to.data,'")'))
+        cat(paste0('data <- readr::read_csv("',path.to.data,'")'))
 
         cat("\n")
         cat(paste('strata1 <- "', fullname_strata, '"', sep = ""))

--- a/R/shortcuts.R
+++ b/R/shortcuts.R
@@ -11,4 +11,4 @@ NULL
 #' @import readxl
 NULL
 
-f_csv <- function(x) data.table::setDT(utils::read.csv(content(x, "raw")))[]
+f_csv <- function(x) data.table::setDT(readr::read_csv(content(x, "raw")))[]


### PR DESCRIPTION
Heads-up: extremely long labels will trigger a `Viewport has zero dimension(s)` error with this fix.

Either we'd remove the call to `ggpubr::ggarange()` and replace `geom_label_repel()` with `geom_label()` as a quick fix or you'd have to shorten the labels manually to get them to render.